### PR TITLE
reset machine id

### DIFF
--- a/prepare-ubuntu-18.04-template.sh
+++ b/prepare-ubuntu-18.04-template.sh
@@ -73,6 +73,11 @@ sed -i 's/preserve_hostname: false/preserve_hostname: true/g' /etc/cloud/cloud.c
 truncate -s0 /etc/hostname
 hostnamectl set-hostname localhost
 
+#reset machine id
+# machine id is used in ubuntu 20.04 lts to request dhcp
+# non-unique machine ids will result in the same ip being assigned to all vms
+truncate -s0 /etc/machine-id
+
 #cleanup apt
 apt clean
 


### PR DESCRIPTION
Machine id is used in ubuntu 20.04 lts as DHCP Client-Id Option 61. A non unique Client-ID results in the same IP being assigned to all the VMs. This deletes it and will be regenerated on reboot. http://manpages.ubuntu.com/manpages/bionic/man5/machine-id.5.html